### PR TITLE
Victory defeat condition + gameStateManager

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Project_Default.xml

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="CustomSecurityManager" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/src/Core/GameState.java
+++ b/src/Core/GameState.java
@@ -1,0 +1,10 @@
+package Core;
+
+public enum GameState {
+    RUNNING,
+    GAME_OVER,
+    VICTORY,
+    EXIT
+
+    // Paused, and other "game" states can be put here.
+}

--- a/src/Core/GameStateManager.java
+++ b/src/Core/GameStateManager.java
@@ -1,0 +1,29 @@
+package Core;
+
+public class GameStateManager {
+    // This is meant to handle user states, such as the game running, them dying and going to game over etc.
+    private static GameStateManager instance;
+    private GameState currentState;
+
+    // honestly debating over singleton usage atm. But ill keep it for now.
+    // read that java garbage collector is more smooth compared to C#
+    private GameStateManager() {
+        currentState = GameState.RUNNING;  // Default state
+    }
+
+    public static synchronized GameStateManager getInstance() {
+        if (instance == null) {
+            instance = new GameStateManager();
+        }
+        return instance;
+    }
+
+    public GameState getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(GameState newState) {
+        this.currentState = newState;
+    }
+
+}

--- a/src/Game.java
+++ b/src/Game.java
@@ -1,3 +1,5 @@
+import Core.GameState;
+import Core.GameStateManager;
 import GameObjects.Data.Info;
 import GameObjects.Entities.HostileCharacter;
 import GameObjects.Entities.HostileEntityType;
@@ -15,20 +17,92 @@ import Interactions.EncounterHandler;
 import java.util.Scanner;
 
 public class Game {
-
     Scanner sc;
-    //Boolean here to exit the game when the user chooses to, OR dies in game.
-    private boolean exitGame = false;
+    GameStateManager gameManager;
 
+    // TODO: migrate Game.java to core package.
     // stuff we can start generating as soon as the program starts running.
     public Game(Scanner sc) {
         // All instances and such can be made here such as zones etc.
-        this.sc = sc;
+        gameManager = GameStateManager.getInstance();
         ZoneManager.getInstance();
+        this.sc = sc;
+    }
+
+    // the core game loop
+    public void run() {
+        Utility.clearConsole();
+        // adding player char and basic items(temp items for now.)
+        PlayerCharacter pc = setupUser(sc);
+        // addItems(pc);
+        // --- TESTS -----------------------
+        // Combat Test
+        // combatTest(pc, addEnemyTemp(), sc);
+
+        // Encounter test
+        // encounterTest(pc, sc);
+        //----------------------------------
+        while (gameManager.getCurrentState() != GameState.EXIT) {
+            switch (gameManager.getCurrentState()) {
+                case RUNNING:
+                    gameMenu(pc, sc);
+                    break;
+                case VICTORY:
+                    handleVictory();
+                    break;
+                case GAME_OVER:
+                    handleGameOver();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    // There are a few mega temporary methods atm, combat related ones being a few.
+    // Wherever we invoke the combat method, we need to make sure it calls "Combat combat = Combat.getInstance();"
+    private void gameMenu(PlayerCharacter pc, Scanner sc) {
+        Utility.clearConsole();
+        System.out.println("Welcome to the game!\n1. Start Game\n2. How to Play\n3. Exit");
+
+        int choice = Utility.checkIfNumber(sc);
+
+        switch (choice) {
+
+            case 1 -> {
+                // TODO: adding player should be here inside game menu when we select start game
+                System.out.println("Starting game...");
+                travelTest(pc, sc);
+                // startGame(); call main game loop
+            }
+            case 2 -> Info.howToPlay(sc);
+            case 3 -> {
+                System.out.println("Exiting game...");
+                gameManager.setCurrentState(GameState.EXIT);
+            }
+        }
+    }
+
+    private static PlayerCharacter setupUser(Scanner sc) {
+        System.out.print("What is your name?: ");
+        String nameInput = Utility.checkIfValidString(sc);
+        // temp input of stats since i got no idea what we are basing it on.
+
+        System.out.println("Your name is " + nameInput + "!");
+        Utility.promptEnterKey(sc);
+        return new PlayerCharacter(nameInput, 18, 3, 2, 4);
+    }
+
+    // methods down here are most likely tests methods.
+    private static void travelTest(PlayerCharacter pc, Scanner sc) {
+        while (true) {
+            pc.getCurrentZone().travelMenu(pc);
+            Utility.promptEnterKey(sc);
+        }
     }
 
     private static HostileCharacter addEnemyTemp() {
-        return new HostileCharacter("Troll", 6, HostileEntityType.TROLLKIN);
+        return new HostileCharacter("Troll", 5, HostileEntityType.TROLLKIN);
     }
 
     private static void combatTest(PlayerCharacter pc, HostileCharacter enemy, Scanner sc) {
@@ -53,34 +127,6 @@ public class Game {
         }
     }
 
-    // the core game loop
-    public void run() {
-        Utility.clearConsole();
-        // adding player char and basic items(temp items for now.)
-        PlayerCharacter pc = setupUser(sc);
-        addItems(pc);
-        // --- TESTS -----------------------
-        // Combat Test
-        // combatTest(pc, addEnemyTemp(), sc);
-
-        // Encounter test
-        // encounterTest(pc, sc);
-        //----------------------------------
-        while (!exitGame) {
-            gameMenu(pc, sc);
-        }
-    }
-
-    private static PlayerCharacter setupUser(Scanner sc) {
-        System.out.print("What is your name?: ");
-        String nameInput = Utility.checkIfValidString(sc);
-        // temp input of stats since i got no idea what we are basing it on.
-
-        System.out.println("Your name is " + nameInput + "!");
-        Utility.promptEnterKey(sc);
-        return new PlayerCharacter(nameInput, 18, 3, 2, 4);
-    }
-
     private static void addItems(PlayerCharacter pc) {
         Equipment sword = new Equipment("A Simple Sword", "Your standard blade as a new adventurer.",
                 new DamageEffect(2));
@@ -92,35 +138,13 @@ public class Game {
         pc.getInventory().addItem(poison);
     }
 
-    // There are a few mega temporary methods atm, combat related ones being a few.
-    // Wherever we invoke the combat method, we need to make sure it calls "Combat combat = Combat.getInstance();"
-    private void gameMenu(PlayerCharacter pc, Scanner sc) {
-        Utility.clearConsole();
-        System.out.println("Welcome to the game!\n1. Start Game\n2. How to Play\n3. Exit");
-
-        int choice = Utility.checkIfNumber(sc);
-
-        switch (choice) {
-
-            case 1 -> {
-                System.out.println("Starting game...");
-                travelTest(pc, sc);
-                // startGame(); call main game loop
-            }
-            case 2 -> Info.howToPlay(sc);
-            case 3 -> {
-                System.out.println("Exiting game...");
-                exitGame = true;
-            }
-        }
+    private void handleVictory() {
+        System.out.println("Victory!");
+        gameManager.setCurrentState(GameState.EXIT);
     }
 
-    // methods down here are most likely tests methods.
-    private static void travelTest(PlayerCharacter pc, Scanner sc) {
-        while (true) {
-            pc.getCurrentZone().travelMenu(pc);
-
-            Utility.promptEnterKey(sc);
-        }
+    private void handleGameOver() {
+        System.out.println("Game Over!");
+        gameManager.setCurrentState(GameState.EXIT);
     }
 }

--- a/src/GameObjects/Entities/Entity.java
+++ b/src/GameObjects/Entities/Entity.java
@@ -142,7 +142,7 @@ public class Entity {
             throw new IllegalArgumentException("Damage value must be positive");
         }
         health -= damageValue;
-        if (!isDead()) {
+        if (isDead()) {
             health = 0;
             System.out.println(name + " took " + damageValue + " damage. " + name + " is dead.");
         } else {

--- a/src/GameObjects/Entities/Entity.java
+++ b/src/GameObjects/Entities/Entity.java
@@ -73,7 +73,7 @@ public class Entity {
     }
 
     public boolean isAlive() {
-        return this.health > 0;
+        return health > 0;
     }
 
     public boolean isFullHP() {

--- a/src/GameObjects/Entities/Entity.java
+++ b/src/GameObjects/Entities/Entity.java
@@ -124,6 +124,7 @@ public class Entity {
         System.out.println(name + "'s max hp is now: " + maxHealth);
     }
 
+    // TODO implement heal/take damage into combat since it's not making use of it currently.
     public void heal(int healingValue) {
         if (healingValue < 0) {
             throw new IllegalArgumentException("Healing value must be positive");

--- a/src/GameObjects/Entities/Entity.java
+++ b/src/GameObjects/Entities/Entity.java
@@ -72,8 +72,8 @@ public class Entity {
         return level;
     }
 
-    public boolean isAlive() {
-        return health > 0;
+    public boolean isDead() {
+        return health <= 0;
     }
 
     public boolean isFullHP() {
@@ -136,12 +136,13 @@ public class Entity {
         System.out.println(name + " healed by " + healingValue + " points. Current health: " + health);
     }
 
+    // used to deal damage to an entity with items. EX: Drink poison, throw bomb.
     public void takeDamage(int damageValue) {
         if (damageValue < 0) {
             throw new IllegalArgumentException("Damage value must be positive");
         }
         health -= damageValue;
-        if (!isAlive()) {
+        if (!isDead()) {
             health = 0;
             System.out.println(name + " took " + damageValue + " damage. " + name + " is dead.");
         } else {

--- a/src/GameObjects/Entities/HostileCharacter.java
+++ b/src/GameObjects/Entities/HostileCharacter.java
@@ -14,13 +14,14 @@ public class HostileCharacter extends Entity {
         this.hostileEntityType = hostileEntityType;
     }
 
-    // Expand logic
+    // TODO: Expand logic for enemy types and experience.
     public HostileEntityType getHostileEntityType() {
         return hostileEntityType;
     }
 
     //calculates the experience based on the level. numbers TBD
     public int calcExperienceGiven() {
-        return (int) (Math.round((level * 20 * 1.25)));
+        return 100;
+        // return (int) (Math.round((level * 20 * 1.25)));
     }
 }

--- a/src/GameObjects/Entities/PlayerCharacter.java
+++ b/src/GameObjects/Entities/PlayerCharacter.java
@@ -68,9 +68,12 @@ public class PlayerCharacter extends Entity {
 
     // TODO: Streamline location for level. and implement "retire" from tavern.
     public void checkGameClearCondition() {
-        if (getLevel() == 2) { //or x boss is dead, but we can prolly add a specific method for when it dies.
+        if (getLevel() == 2) {
+            System.out.println("You have reached high enough level and can now retire in the Tavern!");
+            // easy to create an if check of printing the option if player is x(max) level inside the tavern.
             GameStateManager.getInstance().setCurrentState(GameState.VICTORY);
         }
+        // "else if" x boss is dead, but we can prolly add a specific method for when it dies.
     }
 
     // CURRENTLY not in use in combat at all and only connected to item usage.

--- a/src/GameObjects/Entities/PlayerCharacter.java
+++ b/src/GameObjects/Entities/PlayerCharacter.java
@@ -1,5 +1,7 @@
 package GameObjects.Entities;
 
+import Core.GameState;
+import Core.GameStateManager;
 import GameObjects.Worlds.Zone;
 import GameObjects.Worlds.ZoneManager;
 import GameObjects.Worlds.ZoneType;
@@ -64,23 +66,14 @@ public class PlayerCharacter extends Entity {
         }
     }
 
-
-    public void checkGameOverCondition() {
-        if (!isAlive()) {
-            System.out.println("you died blabla.");
-            //Call on a method within Game file due to not having access to scanner
-            //Would also be more fitting due to it handling the game flow and not the player itself.
-        } else {
-            System.out.println("You died to idk, rolling a 1 on an event or something.");
-        }
-    }
-
+    // TODO: Streamline location for level. and implement "retire" from tavern.
     public void checkGameClearCondition() {
-        if (getLevel() == 10) { //or x boss is dead, but we can prolly add a specific method for when it dies.
-            System.out.println("Ya won woop.");
+        if (getLevel() == 2) { //or x boss is dead, but we can prolly add a specific method for when it dies.
+            GameStateManager.getInstance().setCurrentState(GameState.VICTORY);
         }
     }
 
+    // CURRENTLY not in use in combat at all and only connected to item usage.
     // override method do include a game over check for when the player specifically took damage.
     @Override
     public void takeDamage(int damageValue) {
@@ -88,12 +81,12 @@ public class PlayerCharacter extends Entity {
             throw new IllegalArgumentException("Damage value must be positive");
         }
         health -= damageValue;
-        if (isAlive()) {
-            System.out.println(getName() + " took " + damageValue + " damage. Current health: " + health);
-        } else {
+        if (isDead()) {
             health = 0;
             System.out.println(getName() + " took " + damageValue + " damage. " + getName() + " is dead.");
-            checkGameOverCondition();
+            GameStateManager.getInstance().setCurrentState(GameState.GAME_OVER);
+        } else {
+            System.out.println(getName() + " took " + damageValue + " damage. Current health: " + health);
         }
     }
 

--- a/src/GameObjects/Entities/PlayerCharacter.java
+++ b/src/GameObjects/Entities/PlayerCharacter.java
@@ -87,12 +87,12 @@ public class PlayerCharacter extends Entity {
             throw new IllegalArgumentException("Damage value must be positive");
         }
         health -= damageValue;
-        if (!isAlive()) {
+        if (isAlive()) {
+            System.out.println(getName() + " took " + damageValue + " damage. Current health: " + health);
+        } else {
             health = 0;
             System.out.println(getName() + " took " + damageValue + " damage. " + getName() + " is dead.");
             checkGameOverCondition();
-        } else {
-            System.out.println(getName() + " took " + damageValue + " damage. Current health: " + health);
         }
     }
 

--- a/src/GameObjects/Entities/PlayerCharacter.java
+++ b/src/GameObjects/Entities/PlayerCharacter.java
@@ -29,6 +29,7 @@ public class PlayerCharacter extends Entity {
         while (experience >= 100) {
             experience -= 100;
             levelUp();
+            checkGameClearCondition();
         }
         System.out.println("\nYour current experience is: " + experience + "/100");
     }
@@ -61,6 +62,38 @@ public class PlayerCharacter extends Entity {
 
     public void setCurrentZone(Zone zone) {
         this.currentZone = zone;
+    }
+
+    public void checkGameOverCondition() {
+        if (!isAlive()) {
+            System.out.println("you died blabla.");
+            //Call on a method within Game file due to not having access to scanner
+            //Would also be more fitting due to it handling the game flow and not the player itself.
+        } else {
+            System.out.println("You died to idk, rolling a 1 on an event or something.");
+        }
+    }
+
+    public void checkGameClearCondition() {
+        if (getLevel() == 10) { //or x boss is dead, but we can prolly add a specific method for when it dies.
+            System.out.println("Ya won woop.");
+        }
+    }
+
+    // override method do include a game over check for when the player specifically took damage.
+    @Override
+    public void takeDamage(int damageValue) {
+        if (damageValue < 0) {
+            throw new IllegalArgumentException("Damage value must be positive");
+        }
+        health -= damageValue;
+        if (!isAlive()) {
+            health = 0;
+            System.out.println(getName() + " took " + damageValue + " damage. " + getName() + " is dead.");
+            checkGameOverCondition();
+        } else {
+            System.out.println(getName() + " took " + damageValue + " damage. Current health: " + health);
+        }
     }
 
 }

--- a/src/Interactions/Combat.java
+++ b/src/Interactions/Combat.java
@@ -1,5 +1,7 @@
 package Interactions;
 
+import Core.GameState;
+import Core.GameStateManager;
 import GameObjects.Entities.Entity;
 import GameObjects.Entities.HostileCharacter;
 import GameObjects.Entities.PlayerCharacter;
@@ -105,27 +107,28 @@ public class Combat {
         enemy.setHealth(enemy.getHealth() - playerHitCount);
         playerHitCount = 0;
         enemyHitCount = 0;
-
     }
 
     private void checkVictoryConditionMet() {
         // will prolly have to change this due to us hardcoding a win message and all
         // other handling here.
-        if (player.getHealth() <= 0 && enemy.getHealth() <= 0) {
+        if (player.isDead() && enemy.isDead()) {
             Utility.clearConsole();
             System.out.println("Both of you perish");
             exitingCombat();
 
-        } else if (enemy.getHealth() <= 0) {
+        } else if (enemy.isDead()) {
             Utility.clearConsole();
             printEntityHP(player, Utility.GREEN);
             System.out.println("You have vanquished your foe!");
             ((PlayerCharacter) player).gainExperience(((HostileCharacter) enemy).calcExperienceGiven());
             exitingCombat();
 
-        } else if (player.getHealth() <= 0) {
+        } else if (player.isDead()) {
             Utility.clearConsole();
             System.out.println("You have been slain");
+            // currently calling the state to game over on death here.
+            GameStateManager.getInstance().setCurrentState(GameState.GAME_OVER);
             exitingCombat();
         }
     }

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,3 +1,5 @@
+import Core.GameState;
+import Core.GameStateManager;
 import Global.Utility;
 
 import java.util.Scanner;
@@ -16,6 +18,7 @@ public class Main {
 
             if (replay) {
                 Utility.promptEnterKey(sc);
+                GameStateManager.getInstance().setCurrentState(GameState.RUNNING);
             }
 
         } while (replay);


### PR DESCRIPTION
I realised quite fast that it would work better if we had a gamestatemanager that handles whatever state we are in such as "game over", "running", "victory" and "Exit". This would ease up the local hardcoded checks of player having lost/died across multiple files for example.  Also allows us to have potential situation where instant loss/win outside of combat would be streamlined into the same gamestateshift.

It is possible to win (lvl up > win) and lose (hp = 0 > lose) based on level and health.

Added multiple TODOS and comments for TT and general usage of some methods.

Biggest files affected are: Game.Java(majority movement of code) and Entities package.

If something looks unclear, please contact me or pair review if thats possible.