### PR TITLE
Item repository refactor into Enum/HashMap base.

### DIFF
--- a/src/Game.java
+++ b/src/Game.java
@@ -151,34 +151,11 @@ public class Game {
     }
 
     private static void addItems(PlayerCharacter pc) {
-        Equipment sword = new Equipment(
-                "'A Simple Sword'",
-                "Your standard blade as a new adventurer.",
-                EquipmentType.WEAPON,
-                new DamageEffect(2),
-                100);
-        Equipment bow = new Equipment(
-                "'bow temp'",
-                "Your standard blade as a new adventurer.",
-                EquipmentType.WEAPON,
-                new DamageEffect(2),
-                80);
-        Potion potion = new Potion(
-                "Health Potion",
-                "Chug when ouch",
-                new HealingEffect(5),
-                20);
-        Potion poison = new Potion(
-                "Totally a Health Potion",
-                "Chug for ouch",
-                new DamageEffect(7),
-                30);
-
-        pc.getInventory().addItem(bow);
-        pc.getInventory().addItem(sword);
-        pc.getInventory().addItem(potion);
+        pc.getInventory().addItem(ItemRepository.getItemById("rusty_longsword"));
+        pc.getInventory().addItem(ItemRepository.getItemById("great_axe"));
+        pc.getInventory().addItem(ItemRepository.getItemById("health_potion"));
         for (int i = 1; i <= 7; i++)
-            pc.getInventory().addItem(poison);
+            pc.getInventory().addItem(ItemRepository.getItemById(ItemRepository.POISON_POTION));
     }
     //endregion
 

--- a/src/Game.java
+++ b/src/Game.java
@@ -1,5 +1,6 @@
 import Core.GameState;
 import Core.GameStateManager;
+import GameObjects.Data.ItemId;
 import GameObjects.Data.ItemRepository;
 import GameObjects.Data.PlayerClassRepository;
 import GameObjects.Entities.HostileCharacter;
@@ -151,11 +152,11 @@ public class Game {
     }
 
     private static void addItems(PlayerCharacter pc) {
-        pc.getInventory().addItem(ItemRepository.getItemById("rusty_longsword"));
-        pc.getInventory().addItem(ItemRepository.getItemById("great_axe"));
-        pc.getInventory().addItem(ItemRepository.getItemById("health_potion"));
+        pc.getInventory().addItem(ItemRepository.getItemById(ItemId.RUSTY_LONGSWORD));
+        pc.getInventory().addItem(ItemRepository.getItemById(ItemId.GREAT_AXE));
+        pc.getInventory().addItem(ItemRepository.getItemById(ItemId.HEALTH_POTION));
         for (int i = 1; i <= 7; i++)
-            pc.getInventory().addItem(ItemRepository.getItemById(ItemRepository.POISON_POTION));
+            pc.getInventory().addItem(ItemRepository.getItemById(ItemId.POISON_POTION));
     }
     //endregion
 

--- a/src/Game.java
+++ b/src/Game.java
@@ -6,7 +6,6 @@ import GameObjects.Data.PlayerClassRepository;
 import GameObjects.Entities.HostileCharacter;
 import GameObjects.Entities.HostileEntityType;
 import GameObjects.Entities.PlayerCharacter;
-import GameObjects.Items.*;
 import GameObjects.Worlds.ZoneManager;
 import Global.Utility;
 import Interactions.Adventure;
@@ -37,13 +36,6 @@ public class Game {
         addItems(pc);
         // Combat Test
         // combatTest(pc, addEnemyTemp(), sc);
-        /*Equipment bow = new Equipment(
-                "'bow boi'",
-                "Your standard blade as a new adventurer.",
-                EquipmentType.WEAPON,
-                new DamageEffect(2),
-                10);
-        pc.getInventory().addItem(bow, sc);*/
         // Encounter test
         // encounterTest(pc, sc);
 

--- a/src/Game.java
+++ b/src/Game.java
@@ -155,7 +155,7 @@ public class Game {
         pc.getInventory().spawnItem(ItemRepository.getItemById("great_axe"));
         pc.getInventory().spawnItem(ItemRepository.getItemById("rusty_longsword"));
         pc.getInventory().spawnItem(ItemRepository.getItemById("health_potion"));
-        pc.getInventory().spawnItem(ItemRepository.getItemById("poison_potion"));
+        pc.getInventory().spawnItem(ItemRepository.getItemById(ItemRepository.POISON_POTION));
         pc.getInventory().spawnItem(ItemRepository.getItemById("poison_potion"));
 
     }

--- a/src/Game.java
+++ b/src/Game.java
@@ -1,5 +1,6 @@
 import Core.GameState;
 import Core.GameStateManager;
+import GameObjects.Data.ItemRepository;
 import GameObjects.Data.PlayerClassRepository;
 import GameObjects.Entities.HostileCharacter;
 import GameObjects.Entities.HostileEntityType;
@@ -150,39 +151,12 @@ public class Game {
     }
 
     private static void addItems(PlayerCharacter pc) {
-        Equipment sword = new Equipment(
-                "'A Simple Sword'",
-                "Your standard blade as a new adventurer.",
-                EquipmentType.WEAPON,
-                new DamageEffect(2),
-                100);
-        Equipment bow = new Equipment(
-                "'bow temp'",
-                "Your standard blade as a new adventurer.",
-                EquipmentType.WEAPON,
-                new DamageEffect(2),
-                80);
-        Potion potion = new Potion(
-                "Health Potion",
-                "Chug when ouch",
-                new HealingEffect(5),
-                20);
-        Potion poison = new Potion(
-                "Totally a Health Potion",
-                "Chug for ouch",
-                new DamageEffect(7),
-                30);
 
-        pc.getInventory().spawnItem(bow);
-        pc.getInventory().spawnItem(sword);
-        pc.getInventory().spawnItem(potion);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
-        pc.getInventory().spawnItem(poison);
+        pc.getInventory().spawnItem(ItemRepository.getItemById("great_axe"));
+        pc.getInventory().spawnItem(ItemRepository.getItemById("rusty_longsword"));
+        pc.getInventory().spawnItem(ItemRepository.getItemById("health_potion"));
+        pc.getInventory().spawnItem(ItemRepository.getItemById("poison_potion"));
+        pc.getInventory().spawnItem(ItemRepository.getItemById("poison_potion"));
 
     }
     //endregion

--- a/src/GameObjects/Data/ItemId.java
+++ b/src/GameObjects/Data/ItemId.java
@@ -1,0 +1,10 @@
+package GameObjects.Data;
+
+public enum ItemId {
+    RUSTY_LONGSWORD,
+    METIORIC_IRON_LONGSWORD,
+    GREAT_AXE,
+    POISON_POTION,
+    HEALTH_POTION
+
+}

--- a/src/GameObjects/Data/ItemRepository.java
+++ b/src/GameObjects/Data/ItemRepository.java
@@ -6,35 +6,35 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ItemRepository {
-    private static final Map<String, Item> ITEMS = new HashMap<>();
-
-    // example static final
-    public static final String POISON_POTION = "poison_potion";
+    private static final Map<ItemId, Item> ITEMS = new HashMap<>();
 
     static {
         /*
-        add the items we want into the HashMap to act as our database of items generated.
-        The ID will always be lowercase and use '_' as spacer.
-        This can be sorted by either creating an itemID enum that we make use of to avoid typo.
-        or we create a private static final variable = "string" to call on that variable instead of writing the string.
+        Items instanced within hashmap to be the main reference for the cloning of object.
+        Reason being that the reference ID need to match for items to be able to stack due to Key values.
+
+        Adding an item is done through, as an example;
+        getInventory().addItem(ItemRepository.getItemById(ItemId.HEALTH_POTION));
+
+        We call inventory, addItem gets the item object from this HashMap, with the enum as the KEY.
         */
 
         //region Equipments generated
-        ITEMS.put("rusty_longsword", new Equipment(
+        ITEMS.put(ItemId.RUSTY_LONGSWORD, new Equipment(
                 "Rusty Longsword",
                 "An old and rusty longsword barely sharp enough to cut butter",
                 EquipmentType.WEAPON,
                 new DamageEffect(1),
                 30));
 
-        ITEMS.put("metioric_iron_longsword", new Equipment(
+        ITEMS.put(ItemId.METIORIC_IRON_LONGSWORD, new Equipment(
                 "Metioric Iron longsword",
                 "A longsword made of metioric iron, fallen from the stars, sharp as a razor",
                 EquipmentType.WEAPON,
                 new DamageEffect(2),
                 50));
 
-        ITEMS.put("great_axe", new Equipment(
+        ITEMS.put(ItemId.GREAT_AXE, new Equipment(
                 "Great-axe",
                 "A Great-axe, its simply a great axe",
                 EquipmentType.WEAPON,
@@ -43,13 +43,13 @@ public class ItemRepository {
         //endregion
 
         //region Potions generated
-        ITEMS.put(POISON_POTION, new Potion(
+        ITEMS.put(ItemId.POISON_POTION, new Potion(
                 "Totally a Health Potion",
                 "Chug for ouch",
                 new DamageEffect(7),
                 30));
 
-        ITEMS.put("health_potion", new Potion(
+        ITEMS.put(ItemId.HEALTH_POTION, new Potion(
                 "Health Potion",
                 "Chug when ouch",
                 new HealingEffect(5),
@@ -57,7 +57,7 @@ public class ItemRepository {
         //endregion
     }
 
-    public static Item getItemById(String id) {
-        return ITEMS.get(id);
+    public static Item getItemById(ItemId itemId) {
+        return ITEMS.get(itemId);
     }
 }

--- a/src/GameObjects/Data/ItemRepository.java
+++ b/src/GameObjects/Data/ItemRepository.java
@@ -1,34 +1,56 @@
 package GameObjects.Data;
 
-import GameObjects.Items.DamageEffect;
-import GameObjects.Items.Equipment;
-import GameObjects.Items.EquipmentType;
+import GameObjects.Items.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ItemRepository {
-    public static Equipment getRustyLongsword() {
-        return new Equipment("Rusty Longsword",
+    private static final Map<String, Item> ITEMS = new HashMap<>();
+
+    static {
+        // add the items we want into the HashMap to act as our database of items generated.
+        // The ID will always be lowercase and use '_' as spacer.
+
+        //region Equipments generated
+        ITEMS.put("rusty_longsword", new Equipment(
+                "Rusty Longsword",
                 "An old and rusty longsword barely sharp enough to cut butter",
                 EquipmentType.WEAPON,
                 new DamageEffect(1),
-                30);
-    }
+                30));
 
-    public static Equipment getMetioricIronLongsword() {
-        return new Equipment(
+        ITEMS.put("metioric_iron_longsword", new Equipment(
                 "Metioric Iron longsword",
                 "A longsword made of metioric iron, fallen from the stars, sharp as a razor",
                 EquipmentType.WEAPON,
                 new DamageEffect(2),
-                50);
-    }
+                50));
 
-    public static Equipment getGreataxe() {
-        return new Equipment(
-                "Greataxe",
-                "A Greataxe, its simply a great axe",
+        ITEMS.put("great_axe", new Equipment(
+                "Great-axe",
+                "A Great-axe, its simply a great axe",
                 EquipmentType.WEAPON,
                 new DamageEffect(3),
-                120);
+                120));
+        //endregion
+
+        //region Potions generated
+        ITEMS.put("poison_potion", new Potion(
+                "Totally a Health Potion",
+                "Chug for ouch",
+                new DamageEffect(7),
+                30));
+
+        ITEMS.put("health_potion", new Potion(
+                "Health Potion",
+                "Chug when ouch",
+                new HealingEffect(5),
+                20));
+        //endregion
     }
 
+    public static Item getItemById(String id) {
+        return ITEMS.get(id);
+    }
 }

--- a/src/GameObjects/Data/ItemRepository.java
+++ b/src/GameObjects/Data/ItemRepository.java
@@ -8,9 +8,16 @@ import java.util.Map;
 public class ItemRepository {
     private static final Map<String, Item> ITEMS = new HashMap<>();
 
+    // example static final
+    public static final String POISON_POTION = "poison_potion";
+
     static {
-        // add the items we want into the HashMap to act as our database of items generated.
-        // The ID will always be lowercase and use '_' as spacer.
+        /*
+        add the items we want into the HashMap to act as our database of items generated.
+        The ID will always be lowercase and use '_' as spacer.
+        This can be sorted by either creating an itemID enum that we make use of to avoid typo.
+        or we create a private static final variable = "string" to call on that variable instead of writing the string.
+        */
 
         //region Equipments generated
         ITEMS.put("rusty_longsword", new Equipment(
@@ -36,7 +43,7 @@ public class ItemRepository {
         //endregion
 
         //region Potions generated
-        ITEMS.put("poison_potion", new Potion(
+        ITEMS.put(POISON_POTION, new Potion(
                 "Totally a Health Potion",
                 "Chug for ouch",
                 new DamageEffect(7),

--- a/src/GameObjects/Entities/NeutralCharacter.java
+++ b/src/GameObjects/Entities/NeutralCharacter.java
@@ -1,5 +1,7 @@
 package GameObjects.Entities;
 
+import GameObjects.Data.ItemId;
+import GameObjects.Data.ItemRepository;
 import GameObjects.Items.DamageEffect;
 import GameObjects.Items.HealingEffect;
 import GameObjects.Items.Item;
@@ -23,20 +25,9 @@ public class NeutralCharacter extends Entity {
         setHealth(1000);
         getInventory().setCapacity(100);
 
-        Potion poison = new Potion(
-                "Totally a Health Potion",
-                "Chug for ouch",
-                new DamageEffect(7),
-                30);
-        Potion potion = new Potion(
-                "Health Potion",
-                "Chug when ouch",
-                new HealingEffect(5),
-                20);
-
         for (int i = 0; i <= 3; i++) {
-            getInventory().addItem(poison);
-            getInventory().addItem(potion);
+            getInventory().addItem(ItemRepository.getItemById(ItemId.POISON_POTION));
+            getInventory().addItem(ItemRepository.getItemById(ItemId.HEALTH_POTION));
         }
     }
 

--- a/src/GameObjects/Items/EquipmentManager.java
+++ b/src/GameObjects/Items/EquipmentManager.java
@@ -9,24 +9,24 @@ import java.util.Scanner;
 
 // Really temporary classname due to me not being sure how to work with this.
 public class EquipmentManager {
-    private final Map<EquipmentType, Equipment> equpmentCollection;
+    private final Map<EquipmentType, Equipment> equipmentCollection;
 
     public EquipmentManager() {
-        this.equpmentCollection = new HashMap<>();
+        this.equipmentCollection = new HashMap<>();
         for (EquipmentType slot : EquipmentType.values()) {
-            equpmentCollection.put(slot, null);
+            equipmentCollection.put(slot, null);
         }
     }
 
     public Equipment getEquipment(EquipmentType slot) {
-        return equpmentCollection.get(slot);
+        return equipmentCollection.get(slot);
     }
 
     //region Equip/Un-Equip handling
     public Equipment equipItem(Equipment eq) {
         EquipmentType eqSlot = eq.getEQSlot();
-        Equipment previousEQ = equpmentCollection.get(eqSlot);
-        equpmentCollection.put(eqSlot, eq);
+        Equipment previousEQ = equipmentCollection.get(eqSlot);
+        equipmentCollection.put(eqSlot, eq);
 
         if (previousEQ != null) {
             System.out.println("You put " + previousEQ.getName() + " in your inventory.");
@@ -36,9 +36,9 @@ public class EquipmentManager {
 
     // removes item from equipment, and puts it back into players inventory.
     public Equipment unequipEquipment(EquipmentType slot) {
-        if (equpmentCollection.containsKey(slot)) {
-            Equipment removedItem = equpmentCollection.get(slot);
-            equpmentCollection.put(slot, null);
+        if (equipmentCollection.containsKey(slot)) {
+            Equipment removedItem = equipmentCollection.get(slot);
+            equipmentCollection.put(slot, null);
 
             System.out.println("You unequipped " + removedItem.getName() + ".");
             return removedItem;
@@ -67,7 +67,7 @@ public class EquipmentManager {
         /* Starts on one and loops through each type, printing each type we have
          * Prints out none if its empty, otherwise the name of said item. */
         for (EquipmentType type : EquipmentType.values()) {
-            Equipment eq = equpmentCollection.get(type);
+            Equipment eq = equipmentCollection.get(type);
             String eqPrint = (eq == null) ? "None" : eq.getName();
 
             System.out.println(i + ". " + type.name() + ": " + eqPrint);
@@ -91,10 +91,10 @@ public class EquipmentManager {
                 return;
             }
 
-            if (input > 0 && input <= equpmentCollection.size()) {
+            if (input > 0 && input <= equipmentCollection.size()) {
                 // selects the list based on the order of printed equipments.
                 EquipmentType selectedType = EquipmentType.values()[input - 1];
-                Equipment selectedEquipment = equpmentCollection.get(selectedType);
+                Equipment selectedEquipment = equipmentCollection.get(selectedType);
 
                 if (selectedEquipment == null) {
                     System.out.println("No item equipped in " + selectedType.name() + ".");


### PR DESCRIPTION
Changed ItemRepository to make use of a HashMap with Enums as key to avoid typos.
Change needed to be done to enable stacking of items within inventory and store.

Solved from #37 
- ItemRepository is now a HashMap
- ItemId created with enums for ItemRepository
- Items can now be stacked again due to these changes.